### PR TITLE
apt now updates before trying to install packages

### DIFF
--- a/overlayfs.sh
+++ b/overlayfs.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+apt update
 apt install initramfs-tools
 
 if ! grep overlay /etc/initramfs-tools/modules > /dev/null; then


### PR DESCRIPTION
Got some errors during install due to having out of date package lists. This will stop it happening in the future.