### PR TITLE
u-boot support, and /boot on root support

### DIFF
--- a/overctl
+++ b/overctl
@@ -1,9 +1,13 @@
 #!/bin/sh
 
-BOOT=/boot
-CMDLINE=cmdline.txt
-CMDLINE_RO=cmdline.txt.overlay
-CMDLINE_RW=cmdline.txt.orig
+BOOT="$(awk '$2 ~ /^\/boot/ { print $2; exit }' /proc/mounts)"
+[ -n "${BOOT}" -a -r "${BOOT}/config.txt" ] || BOOT="/boot"
+BOOT="$(readlink -f "${BOOT}/config.txt" 2>/dev/null)"
+BOOT="$(dirname "${BOOT:-/boot/config.txt}")"
+
+CMDLINE="cmdline.txt"
+CMDLINE_RO="cmdline.txt.overlay"
+CMDLINE_RW="cmdline.txt.orig"
 
 UBOOTENV=armbianEnv.txt
 
@@ -22,8 +26,9 @@ print_usage() {
 [ "$1" = "--help" -o "$1" = "-h" ] && { print_usage; exit 0; }
 
 # Change to the working directory
-mount $BOOT >/dev/null 2>&1 || : # Some systems don't mount /boot, if they see out bind mount
-cd $BOOT
+mount /boot     >/dev/null 2>&1 || : # Some systems don't mount /boot, if they see our bind mount
+mount "${BOOT}" >/dev/null 2>&1 || : # Some systems don't mount /boot, if they see our bind mount
+cd "${BOOT}"
 
 # Check that the files we need are present and readable
 if [ -r $CMDLINE ]; then
@@ -79,9 +84,9 @@ check_permission() {
 	local cmdline=$CMDLINE
 	[ -r $CMDLINE ] || cmdline=$UBOOTENV
 	if ! touch $cmdline 2>/dev/null; then
-		mount -o remount,rw $BOOT 2>/dev/null
-		[ $? -eq 0 ] || { echo "ERROR: failed to mount $BOOT RW" >&2; exit 1; }
-		boot_remount=y
+		mount -o remount,rw "${BOOT}" 2>/dev/null && boot_remount="${BOOT}" ||
+		mount -o remount,rw /boot     2>/dev/null && boot_remount="/boot" ||
+		{ echo "ERROR: failed to mount $BOOT RW" >&2; exit 1; }
 	fi
 
 	return 0
@@ -133,9 +138,9 @@ fi
 echo "/ will be mounted $newstate on next boot" >&2
 
 # Remount BOOT read-only if that was the way we found it
-if [ "$boot_remount" = "y" ]; then
-	mount -o remount,ro $BOOT 2>/dev/null
-	[ $? -eq 0 ] || { echo "failed to mount $BOOT RO" >&2; exit 1; }
+if [ -n "$boot_remount" ]; then
+	mount -o remount,ro "$boot_remount" 2>/dev/null ||
+	{ echo "failed to mount ${boot_remount} RO" >&2; exit 1; }
 fi
 
 # The End

--- a/overctl
+++ b/overctl
@@ -84,8 +84,8 @@ check_permission() {
 	local cmdline=$CMDLINE
 	[ -r $CMDLINE ] || cmdline=$UBOOTENV
 	if ! touch $cmdline 2>/dev/null; then
-		mount -o remount,rw "${BOOT}" 2>/dev/null && boot_remount="${BOOT}" ||
-		mount -o remount,rw /boot     2>/dev/null && boot_remount="/boot" ||
+		mount -o remount,rw "${BOOT}" 2>/dev/null && boot_remount="${BOOT}" || {
+		mount -o remount,rw /boot     2>/dev/null && boot_remount="/boot"; } ||
 		{ echo "ERROR: failed to mount $BOOT RW" >&2; exit 1; }
 	fi
 

--- a/overctl
+++ b/overctl
@@ -5,6 +5,8 @@ CMDLINE=cmdline.txt
 CMDLINE_RO=cmdline.txt.overlay
 CMDLINE_RW=cmdline.txt.orig
 
+UBOOTENV=armbianEnv.txt
+
 print_usage() {
 	cat <<-TEXT
 		Usage: ${0##*/} [-h|-r|-s|-t|-w]
@@ -23,9 +25,13 @@ print_usage() {
 cd $BOOT
 
 # Check that the files we need are present and readable
-for file in $CMDLINE $CMDLINE_RO $CMDLINE_RW; do
-	[ -r $file ] || { echo "ERROR: missing file $file" >&2 && exit 1; }
-done
+if [ -r $CMDLINE ]; then
+	for file in $CMDLINE $CMDLINE_RO $CMDLINE_RW; do
+		[ -r $file ] || { echo "ERROR: missing file $file" >&2 && exit 1; }
+	done
+elif ! [ -r $UBOOTENV ]; then
+	echo "ERROR: missing file $UBOOTENV" >&2 && exit 1
+fi
 
 # Process arg (if any)
 case "$1" in
@@ -42,18 +48,26 @@ case "$1" in
 			;;
 esac
 
-line_active=$(cat $CMDLINE)
-line_ro=$(cat $CMDLINE_RO)
-line_rw=$(cat $CMDLINE_RW)
+if [ -r "$CMDLINE" ]; then
+	line_active=$(cat $CMDLINE)
+	line_ro=$(cat $CMDLINE_RO)
+	line_rw=$(cat $CMDLINE_RW)
 
-# Check which CMDLINE is in use, this doubles as a sanity check
-if [ "$line_active" = "$line_ro" ]; then
-	state=RO
-elif [ "$line_active" = "$line_rw" ]; then
-	state=RW
+	# Check which CMDLINE is in use, this doubles as a sanity check
+	if [ "$line_active" = "$line_ro" ]; then
+		state=RO
+	elif [ "$line_active" = "$line_rw" ]; then
+		state=RW
+	else
+		echo "ERROR: $CMDLINE matches neither $CMDLINE_RO, nor $CMDLINE_RW" >&2
+		exit 1
+	fi
 else
-	echo "ERROR: $CMDLINE matches neither $CMDLINE_RO, nor $CMDLINE_RW" >&2
-	exit 1
+	if grep boot=overlay $UBOOTENV >/dev/null; then
+		state=RO
+	else
+		state=RW
+	fi
 fi
 
 check_permission() {
@@ -61,7 +75,9 @@ check_permission() {
 	[ $(id -u) -eq 0 ] || { echo "ERROR: requires root privileges" >&2; exit 1; }
 
 	# Check that we can write to CMDLINE, otherwise try to remount BOOT
-	if ! touch $CMDLINE 2>/dev/null; then
+	local cmdline=$CMDLINE
+	[ -r $CMDLINE ] || cmdline=$UBOOTENV
+	if ! touch $cmdline 2>/dev/null; then
 		mount -o remount,rw $BOOT 2>/dev/null
 		[ $? -eq 0 ] || { echo "ERROR: failed to mount $BOOT RW" >&2; exit 1; }
 		boot_remount=y
@@ -89,10 +105,27 @@ elif [ "$action" = "$state" ]; then
 	echo "/ is already set to be mounted $state on next boot" >&2
 	exit 1
 elif [ "$state" = "RO" ]; then
-	check_permission && cp $CMDLINE_RW $CMDLINE
+	check_permission && {
+		if [ -r "$CMDLINE" ]; then
+			cp $CMDLINE_RW $CMDLINE
+		else
+			sed -i '/^extraargs=/{s/boot=overlay//;s/  */ /g;s/ *$//};/^extraargs=$/d' $UBOOTENV
+		fi
+	}
 	newstate=RW
 elif [ "$state" = "RW" ]; then
-	check_permission && cp $CMDLINE_RO $CMDLINE
+	check_permission && {
+		if [ -r "$CMDLINE" ]; then
+			cp $CMDLINE_RO $CMDLINE
+		else
+			sed -i '/^extraargs=/{
+			          s/boot=overlay//g;s/  */ /g;s/=/&boot=overlay /;s/ *$//
+			          :1;N;b1
+			        }
+			        $a\
+extraargs=boot=overlay' $UBOOTENV
+		fi
+	}
 	newstate=RO
 fi
 

--- a/overctl
+++ b/overctl
@@ -22,6 +22,7 @@ print_usage() {
 [ "$1" = "--help" -o "$1" = "-h" ] && { print_usage; exit 0; }
 
 # Change to the working directory
+mount $BOOT >/dev/null 2>&1 || : # Some systems don't mount /boot, if they see out bind mount
 cd $BOOT
 
 # Check that the files we need are present and readable

--- a/overlay
+++ b/overlay
@@ -49,8 +49,13 @@ local_mount_root()
 	mount -t overlay \
 	    -olowerdir=/lower,upperdir=/upper/data,workdir=/upper/work \
 	    overlay ${rootmnt}
+	# R/W access to the /boot directory will disappear when we pivot
+	[ -z "`ls -A /lower/boot 2>/dev/null`" ] || mount -o bind /lower/boot ${rootmnt}/boot
 
-        # R/W access to the /boot directory will disappear when we pivot
-        [ -n "`ls -A /lower/boot`" ] &&
-	mount -o bind /lower/boot ${rootmnt}/boot
+	# Some users don't actually want a fully R/O system, but instead
+	# merely want to reduce the amount of writes to minimize risk of
+	# file system corruption.
+	# Uncomment and edit as needed.
+	mount -o bind /lower/home ${rootmnt}/home >&/dev/null || :
+	mount -o remount,rw ${rootmnt}/home >&/dev/null || :
 }

--- a/overlay
+++ b/overlay
@@ -11,11 +11,14 @@
 local_mount_root()
 {
 	local_top
+	if [ -z "${ROOT}" ]; then
+		panic "No root device specified. Boot arguments must include a root= parameter."
+	fi
 	local_device_setup "${ROOT}" "root file system"
 	ROOT="${DEV}"
 
 	# Get the root filesystem type if not set
-	if [ -z "${ROOTFSTYPE}" ]; then
+	if [ -z "${ROOTFSTYPE}" ] || [ "${ROOTFSTYPE}" = auto ]; then
 		FSTYPE=$(get_fstype "${ROOT}")
 	else
 		FSTYPE=${ROOTFSTYPE}
@@ -27,17 +30,18 @@ local_mount_root()
 	# N.B. this code still lacks error checking
 
 	modprobe ${FSTYPE}
-	checkfs ${ROOT} root "${FSTYPE}"
+	checkfs "${ROOT}" root "${FSTYPE}"
 
 	# Create directories for root and the overlay
 	mkdir /lower /upper
 
 	# Mount read-only root to /lower
 	if [ "${FSTYPE}" != "unknown" ]; then
-		mount -r -t ${FSTYPE} ${ROOTFLAGS} ${ROOT} /lower
+		mount ${FSTYPE:+-t "${FSTYPE}"} ${ROOTFLAGS} "${ROOT}" /lower
 	else
 		mount -r ${ROOTFLAGS} ${ROOT} /lower
 	fi
+	mountroot_status="$?"
 
 	modprobe overlay
 
@@ -49,13 +53,20 @@ local_mount_root()
 	mount -t overlay \
 	    -olowerdir=/lower,upperdir=/upper/data,workdir=/upper/work \
 	    overlay ${rootmnt}
+
 	# R/W access to the /boot directory will disappear when we pivot
-	[ -z "`ls -A /lower/boot 2>/dev/null`" ] || mount -o bind /lower/boot ${rootmnt}/boot
+	if [ -d /lower/boot/firmware ]; then
+	   [ -z "`ls -A /lower/boot/firmware 2>/dev/null`" ] ||
+           mount -o bind /lower/boot/firmware ${rootmnt}/boot/firmware >/dev/null 2>&1 || :
+        else
+	   [ -z "`ls -A /lower/boot          2>/dev/null`" ] ||
+	   mount -o bind /lower/boot ${rootmnt}/boot >/dev/null 2>&1 || :
+	fi
 
 	# Some users don't actually want a fully R/O system, but instead
 	# merely want to reduce the amount of writes to minimize risk of
 	# file system corruption.
 	# Uncomment and edit as needed.
-	mount -o bind /lower/home ${rootmnt}/home >&/dev/null || :
-	mount -o remount,rw ${rootmnt}/home >&/dev/null || :
+	mount -o bind /lower/home ${rootmnt}/home >/dev/null 2>&1 || :
+	mount -o remount,rw ${rootmnt}/home >/dev/null 2>&1 || :
 }

--- a/overlay
+++ b/overlay
@@ -49,4 +49,7 @@ local_mount_root()
 	mount -t overlay \
 	    -olowerdir=/lower,upperdir=/upper/data,workdir=/upper/work \
 	    overlay ${rootmnt}
+
+        # R/W access to the /boot directory will disappear when we pivot
+        mount -o bind /lower/boot ${rootmnt}/boot
 }

--- a/overlay
+++ b/overlay
@@ -51,5 +51,6 @@ local_mount_root()
 	    overlay ${rootmnt}
 
         # R/W access to the /boot directory will disappear when we pivot
-        mount -o bind /lower/boot ${rootmnt}/boot
+        [ -n "`ls -A /lower/boot`" ] &&
+	mount -o bind /lower/boot ${rootmnt}/boot
 }

--- a/overlayfs.sh
+++ b/overlayfs.sh
@@ -14,7 +14,7 @@ cp overlay /etc/initramfs-tools/scripts
 # Different distributions place the boot files into slightly different
 # locations. So, make an effort to automatically locate them.
 boot="$(awk '$2 ~ /^\/boot/ { print $2; exit }' /proc/mounts)"
-[ -n "${boot}" -a -r "${cfg}/config.txt" ] || cfg="/boot"
+[ -n "${boot}" -a -r "${boot}/config.txt" ] && cfg="${boot}" || cfg="/boot"
 cfg="$(readlink -f "${cfg}/config.txt" 2>/dev/null)"
 cfg="$(dirname "${cfg:-/boot/config.txt}")"
 

--- a/overlayfs.sh
+++ b/overlayfs.sh
@@ -1,38 +1,48 @@
 #!/bin/bash
 
 apt install initramfs-tools busybox-static
+[ -r /usr/share/initramfs-tools/hooks/zz-busybox-initramfs ] &&
+sed 's/^\(BB_BIN=\).*/\1\/usr\/bin\/busybox/' /usr/share/initramfs-tools/hooks/zz-busybox-initramfs >/usr/share/initramfs-tools/hooks/zzz-busybox-initramfs &&
+chmod 755 /usr/share/initramfs-tools/hooks/zzz-busybox-initramfs
 
 if ! grep overlay /etc/initramfs-tools/modules > /dev/null; then
   echo overlay >> /etc/initramfs-tools/modules
 fi
 
 cp overlay /etc/initramfs-tools/scripts
-mount -o remount,rw /boot
+
+# Different distributions place the boot files into slightly different
+# locations. So, make an effort to automatically locate them.
+boot="$(awk '$2 ~ /^\/boot/ { print $2; exit }' /proc/mounts)"
+[ -n "${boot}" -a -r "${cfg}/config.txt" ] || cfg="/boot"
+cfg="$(readlink -f "${cfg}/config.txt" 2>/dev/null)"
+cfg="$(dirname "${cfg:-/boot/config.txt}")"
+
+mount -o remount,rw "${boot}"
 
 # This is needed for the u-boot
-if [ -r /boot/armbianEnv.txt ]; then
-  if ! grep boot=overlay /boot/armbianEnv.txt > /dev/null; then
+if [ -r "${cfg}/armbianEnv.txt" ]; then
+  if ! grep boot=overlay "${cfg}/armbianEnv.txt" > /dev/null; then
     sed -i '/^extraargs=/{
               s/boot=overlay//g;s/  */ /g;s/=/&boot=overlay /;s/ *$//
 	      :1;N;b1
             }
 	    $a\
-extraargs=boot=overlay' /boot/armbianEnv.txt
+extraargs=boot=overlay' "${cfg}/armbianEnv.txt"
   fi
 fi
 
 update-initramfs -c -k $(uname -r)
 
-# This is needed for the Raspberry Pi bootloader
-if [ -r /boot/config.txt ]; then
-  mv /boot/initrd.img-$(uname -r) /boot/initrd7.img
+# This is needed for the Raspberry Pi bootloader.
+if [ -r "${cfg}/config.txt" ]; then
+# mv "${cfg}/initrd.img-$(uname -r)" "${cfg}/initrd7.img"
+# sed -e "s/initramfs.*//" -i "${cfg}/config.txt"
+# echo initramfs initrd7.img >> "${cfg}/config.txt"
 
-  sed -e "s/initramfs.*//" -i /boot/config.txt
-  echo initramfs initrd7.img >> /boot/config.txt
-
-  sed -e 's/.*/ & /;:1;s/ boot=overlay / /g;t1;s/ \+/ /g;s/^ //;s/ $//' /boot/cmdline.txt > /boot/cmdline.txt.orig &&
-  sed -e "s/.*/boot=overlay &/" /boot/cmdline.txt.orig >/boot/cmdline.txt.overlay &&
-  cp /boot/cmdline.txt.overlay /boot/cmdline.txt
+  sed -e 's/.*/ & /;:1;s/ boot=overlay / /g;t1;s/ \+/ /g;s/^ //;s/ $//' "${cfg}/cmdline.txt" > "${cfg}/cmdline.txt.orig" &&
+  sed -e "s/.*/boot=overlay &/" "${cfg}/cmdline.txt.orig" >"${cfg}/cmdline.txt.overlay" &&
+  cp "${cfg}/cmdline.txt.overlay" "${cfg}/cmdline.txt"
 fi
 
 cp overctl /usr/local/sbin

--- a/overlayfs.sh
+++ b/overlayfs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-apt install initramfs-tools
+apt install initramfs-tools busybox-static
 
 if ! grep overlay /etc/initramfs-tools/modules > /dev/null; then
   echo overlay >> /etc/initramfs-tools/modules

--- a/overlayfs.sh
+++ b/overlayfs.sh
@@ -8,15 +8,31 @@ fi
 
 cp overlay /etc/initramfs-tools/scripts
 
+# This is needed for the u-boot
+if [ -r /boot/armbianEnv.txt ]; then
+  if ! grep boot=overlay /boot/armbianEnv.txt > /dev/null; then
+    sed -i '/^extraargs=/{
+              s/boot=overlay//g;s/  */ /g;s/=/&boot=overlay /;s/ *$//
+	      :1;N;b1
+            }
+	    $a\
+extraargs=boot=overlay' /boot/armbianEnv.txt
+  fi
+fi
+
 update-initramfs -c -k $(uname -r)
-mv /boot/initrd.img-$(uname -r) /boot/initrd7.img
 
-sed -e "s/initramfs.*//" -i /boot/config.txt
-echo initramfs initrd7.img >> /boot/config.txt
+# This is needed for the Raspberry Pi bootloader
+if [ -r /boot/config.txt ]; then
+  mv /boot/initrd.img-$(uname -r) /boot/initrd7.img
 
-cp /boot/cmdline.txt /boot/cmdline.txt.orig
-sed -e "s/\(.*\)/boot=overlay \1/" -i /boot/cmdline.txt
-cp /boot/cmdline.txt /boot/cmdline.txt.overlay
+  sed -e "s/initramfs.*//" -i /boot/config.txt
+  echo initramfs initrd7.img >> /boot/config.txt
+
+  sed -e 's/boot=overlay //' /boot/cmdline.txt > /boot/cmdline.txt.orig
+  sed -e "s/\(.*\)/boot=overlay \1/" -i /boot/cmdline.txt
+  cp /boot/cmdline.txt /boot/cmdline.txt.overlay
+fi
 
 cp overctl /usr/local/sbin
 

--- a/overlayfs.sh
+++ b/overlayfs.sh
@@ -7,6 +7,7 @@ if ! grep overlay /etc/initramfs-tools/modules > /dev/null; then
 fi
 
 cp overlay /etc/initramfs-tools/scripts
+mount -o remount,rw /boot
 
 # This is needed for the u-boot
 if [ -r /boot/armbianEnv.txt ]; then
@@ -29,11 +30,11 @@ if [ -r /boot/config.txt ]; then
   sed -e "s/initramfs.*//" -i /boot/config.txt
   echo initramfs initrd7.img >> /boot/config.txt
 
-  sed -e 's/boot=overlay //' /boot/cmdline.txt > /boot/cmdline.txt.orig
-  sed -e "s/\(.*\)/boot=overlay \1/" -i /boot/cmdline.txt
-  cp /boot/cmdline.txt /boot/cmdline.txt.overlay
+  sed -e 's/.*/ & /;:1;s/ boot=overlay / /g;t1;s/ \+/ /g;s/^ //;s/ $//' /boot/cmdline.txt > /boot/cmdline.txt.orig &&
+  sed -e "s/.*/boot=overlay &/" /boot/cmdline.txt.orig >/boot/cmdline.txt.overlay &&
+  cp /boot/cmdline.txt.overlay /boot/cmdline.txt
 fi
 
 cp overctl /usr/local/sbin
 
-sed -e "s/\(.*\/boot.*\)defaults\(.*\)/\1defaults,ro\2/" -i /etc/fstab
+sed -e "/.*\/boot.*ro/b;s/\(.*\/boot.*\)defaults\(.*\)/\1defaults,ro\2/" -i /etc/fstab


### PR DESCRIPTION
I was trying to use your scripts on one of my devices that uses Das U-Boot to load Armbian. Interestingly enough, it also doesn't have a dedicated /boot partition, but just uses a regular folder in the root filesystem. This means, you can't actually access /boot and make it r/w from within the overlay filesystem.

Added support to make all of that work. I don't know whether it works for other Das U-Boot systems, nor whether it works for Armbian systems that use a different way of booting. But I tried to keep things as generic as I could, so it shouldn't break anything and it stands at least a fighting chance to work on other systems.