### PR TITLE
abort reinitialization

### DIFF
--- a/overlayfs.sh
+++ b/overlayfs.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if grep -qE '^overlay$' /etc/initramfs-tools/modules; then
+	printf 'Seems like overlayfs was already initialized, abort.\n'
+	exit 1
+fi
+
 apt install initramfs-tools
 
 if ! grep overlay /etc/initramfs-tools/modules > /dev/null; then


### PR DESCRIPTION
initializing again might break --toggle.
When overlayfs is enabled and a reinitialization is attempted,
cmdline.txt.orig will be overwritten with the current cmdline.txt.overlay.
(because cmdline.txt equals cmdline.txt.overlay at that point and will
be backed up).
Additionally 'boot=overlay' will be added a second time to cmdline.txt.
Overall it does not seem to be a good idea to reinitialize, therefore
such an attempt should be aborted.

Signed-off-by: Julian Heuking <jheuking@googlemail.com>